### PR TITLE
set, not header

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,9 +14,9 @@ app.use(bodyparser.json());
 
 // cors
 app.use(function(req, res, next) {
-  res.header('access-control-allow-origin', '*');
-  res.header('access-control-allow-methods', 'get,put,post,delete,options');
-  res.header('access-control-allow-headers', 
+  res.set('access-control-allow-origin', '*');
+  res.set('access-control-allow-methods', 'get,put,post,delete,options');
+  res.set('access-control-allow-headers', 
     'origin, x-requested-with, content-type, accept, authentication, content-length');
 
   if ('options' === req.method) {


### PR DESCRIPTION
Express uses `set()` for header values now.
